### PR TITLE
Chore/Migrate CI workflows to use self-hosted runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -150,7 +150,7 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/basis-data-ltt:v1.0.prod-$SHORT_SHA
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: [evolto3-be-runner]
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     name: Publish Release and Packages
-    runs-on: ubuntu-latest
+    runs-on: [evolto3-be-runner]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   security:
     name: Security and Quality Checks
-    runs-on: ubuntu-latest
+    runs-on: [evolto3-be-runner]
     permissions:
       contents: read
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a custom self-hosted runner instead of the default `ubuntu-latest` runner. This change ensures that all jobs in the affected workflows execute on the `[evolto3-be-runner]` runner, which may provide better control over the build environment or improved performance.

**Workflow runner updates:**

* Changed the `runs-on` configuration from `ubuntu-latest` to `[evolto3-be-runner]` for the `publish` job in `.github/workflows/go.yml`
* Changed the `runs-on` configuration from `ubuntu-latest` to `[evolto3-be-runner]` for the `release` job in `.github/workflows/release.yml`
* Changed the `runs-on` configuration from `ubuntu-latest` to `[evolto3-be-runner]` for the `security` job in `.github/workflows/security.yml`