### PR TITLE
Bugfix/Update Go version to 1.25 in release workflow and go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Log in to GHCR
       uses: docker/login-action@v3
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Log in to GHCR
       uses: docker/login-action@v3
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.25'
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-            go-version: '1.24'
+            go-version: '1.25'
             cache: true
       - name: Cache Go modules and build cache
         uses: actions/cache@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ariebrainware/basis-data-ltt
 
 go 1.25
+toolchain go1.25.7
 
 require (
 	github.com/gin-gonic/gin v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ariebrainware/basis-data-ltt
 
-go 1.25.7
+go 1.25
 
 require (
 	github.com/gin-gonic/gin v1.11.0


### PR DESCRIPTION
This pull request updates the Go version used throughout the project to 1.25, ensuring consistency across development, CI workflows, and release processes. It also updates the `go.mod` file to use the new Go version and specifies the toolchain version.

Go version updates:

* Updated the Go version to `1.25` in all GitHub Actions workflow files, including `.github/workflows/go.yml`, `.github/workflows/release.yml`, and `.github/workflows/security.yml`, replacing previous versions (`1.20` and `1.24`). [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL30-R30) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL96-R96) [[3]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL163-R163) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24) [[5]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL23-R23)

Go module configuration:

* Updated `go.mod` to set `go 1.25` and added `toolchain go1.25.7` for toolchain specification.