### PR TITLE
Feature/Add optional custom pricing support for transaction items

### DIFF
--- a/endpoint/transaction.go
+++ b/endpoint/transaction.go
@@ -15,8 +15,9 @@ import (
 )
 
 type transactionItemRequest struct {
-	ItemID   uint `json:"item_id"`
-	Quantity int  `json:"quantity"`
+	ItemID   uint   `json:"item_id"`
+	Quantity int    `json:"quantity"`
+	Price    *int64 `json:"price,omitempty"`
 }
 
 type updateTransactionRequest struct {
@@ -168,6 +169,7 @@ func calculateTransactionAmountAndAdjustItems(tx *gorm.DB, therapistID uint, ite
 	}
 
 	aggregatedQuantities := make(map[uint]int)
+	itemPrices := make(map[uint]int64)
 	for _, itemRequest := range items {
 		if itemRequest.ItemID == 0 {
 			return 0, &transactionUserError{msg: "item_id is required for each item"}
@@ -176,6 +178,9 @@ func calculateTransactionAmountAndAdjustItems(tx *gorm.DB, therapistID uint, ite
 			return 0, &transactionUserError{msg: "item quantity must be greater than 0"}
 		}
 		aggregatedQuantities[itemRequest.ItemID] += itemRequest.Quantity
+		if itemRequest.Price != nil {
+			itemPrices[itemRequest.ItemID] = *itemRequest.Price
+		}
 	}
 
 	itemIDs := make([]uint, 0, len(aggregatedQuantities))
@@ -204,7 +209,11 @@ func calculateTransactionAmountAndAdjustItems(tx *gorm.DB, therapistID uint, ite
 			return 0, err
 		}
 
-		totalAmount += int64(quantity) * item.Price
+		price := item.Price
+		if customPrice, exists := itemPrices[itemID]; exists {
+			price = customPrice
+		}
+		totalAmount += int64(quantity) * price
 	}
 
 	return totalAmount, nil
@@ -431,9 +440,19 @@ func UpdateTransaction(c *gin.Context) {
 
 			var modelItems []model.TransactionItem
 			for _, itemReq := range req.Items {
+				price := int64(0)
+				if itemReq.Price != nil {
+					price = *itemReq.Price
+				} else {
+					var item model.Item
+					if err := tx.Where("id = ? AND deleted_at IS NULL", itemReq.ItemID).First(&item).Error; err == nil {
+						price = item.Price
+					}
+				}
 				modelItems = append(modelItems, model.TransactionItem{
 					ItemID:   itemReq.ItemID,
 					Quantity: itemReq.Quantity,
+					Price:    price,
 				})
 			}
 			itemsJSON, err := json.Marshal(modelItems)

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -5,8 +5,9 @@ import "gorm.io/gorm"
 // TransactionItem represents an item consumed by a transaction.
 // @Description Transaction item detail information
 type TransactionItem struct {
-	ItemID   uint `json:"item_id" example:"1"`
-	Quantity int  `json:"quantity" example:"2"`
+	ItemID   uint  `json:"item_id" example:"1"`
+	Quantity int   `json:"quantity" example:"2"`
+	Price    int64 `json:"price" example:"10000"`
 }
 
 // Transaction represents a payment transaction for a treatment.


### PR DESCRIPTION
# Description

## Overview
This PR allows therapists to edit the price of individual items in a transaction. This enables them to apply discounts or custom pricing directly during transaction creation and updates, rather than strictly using the default database-defined item price.

## Proposed Changes

### 1. Database Model Updates
* Modified [model/transaction.go](file:///Users/ariebrainware/go/src/github.com/ariebrainware/ltt-infrastructure/basis-data-ltt/model/transaction.go):
  * Added `Price` (`int64`) to the `TransactionItem` struct (serialized into the JSON `items` field in the database).

### 2. Endpoint/API Logic Updates
* Modified [endpoint/transaction.go](file:///Users/ariebrainware/go/src/github.com/ariebrainware/ltt-infrastructure/basis-data-ltt/endpoint/transaction.go):
  * Updated `transactionItemRequest` to accept an optional `Price` pointer (`*int64`) in JSON.
  * Updated `calculateTransactionAmountAndAdjustItems` to check if a custom price was submitted in the request. If present, it overrides the default item price for transaction total calculation.
  * Updated `UpdateTransaction` handler: when saving item details to `model.TransactionItem`, it checks if a custom price was passed in the request. If not, it fetches the item's default price from the database to ensure a fallback price is always stored.

## Verification
- Verified endpoint builds and parses transaction item requests successfully.
- Confirmed that total amount calculation correctly applies custom item prices when provided.
