### PR TITLE
Bugfix/Therapist Basic Functionality

### DIFF
--- a/endpoint/authentication.go
+++ b/endpoint/authentication.go
@@ -21,9 +21,10 @@ type LoginRequest struct {
 }
 
 type LoginResponse struct {
-	Token  string `json:"token" example:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."`
-	Role   string `json:"role" example:"Admin"`
-	UserID uint   `json:"user_id" example:"1"`
+	Token       string `json:"token" example:"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."`
+	Role        string `json:"role" example:"Admin"`
+	UserID      uint   `json:"user_id" example:"1"`
+	TherapistID uint   `json:"therapist_id,omitempty" example:"1"`
 }
 
 // Login godoc
@@ -223,8 +224,18 @@ func finalizeLogin(ctx loginContext, user *model.User, plain string) bool {
 		_ = util.AddSessionToUserSet(session.UserID, tokenString, exp)
 	}
 
+	var therapistID uint
+	if uint32(role.ID) == model.RoleTherapist {
+		ctx.DB.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+	}
+
 	util.LogLoginSuccess(util.LoginParams{UserID: user.ID, Email: user.Email, IP: ctx.CI.IP, UserAgent: ctx.CI.Agent})
-	util.CallSuccessOK(ctx.C, util.APISuccessParams{Msg: "Login successful", Data: LoginResponse{Token: tokenString, Role: role.Name, UserID: user.ID}})
+	util.CallSuccessOK(ctx.C, util.APISuccessParams{Msg: "Login successful", Data: LoginResponse{
+		Token:       tokenString,
+		Role:        role.Name,
+		UserID:      user.ID,
+		TherapistID: therapistID,
+	}})
 	return true
 }
 

--- a/endpoint/authentication.go
+++ b/endpoint/authentication.go
@@ -226,7 +226,15 @@ func finalizeLogin(ctx loginContext, user *model.User, plain string) bool {
 
 	var therapistID uint
 	if uint32(role.ID) == model.RoleTherapist {
-		ctx.DB.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+		tx := ctx.DB.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+		if tx.Error != nil {
+			util.CallServerError(ctx.C, util.APIErrorParams{Msg: "Failed to load therapist info", Err: tx.Error})
+			return false
+		}
+		if tx.RowsAffected == 0 {
+			util.CallServerError(ctx.C, util.APIErrorParams{Msg: "Therapist record not found for user", Err: fmt.Errorf("therapist not found for email %s", user.Email)})
+			return false
+		}
 	}
 
 	util.LogLoginSuccess(util.LoginParams{UserID: user.ID, Email: user.Email, IP: ctx.CI.IP, UserAgent: ctx.CI.Agent})

--- a/endpoint/treatment.go
+++ b/endpoint/treatment.go
@@ -513,7 +513,7 @@ func UpdateTreatment(c *gin.Context) {
 				return
 			}
 			if updates.TherapistID != 0 && updates.TherapistID != uint(therapistID) {
-				util.CallUserError(c, util.APIErrorParams{
+				util.CallUserForbidden(c, util.APIErrorParams{
 					Msg: "You cannot change the therapist assigned to this treatment",
 					Err: fmt.Errorf("therapist cannot reassign treatment to therapist %d", updates.TherapistID),
 				})

--- a/endpoint/treatment.go
+++ b/endpoint/treatment.go
@@ -497,6 +497,31 @@ func UpdateTreatment(c *gin.Context) {
 		return
 	}
 
+	roleIDVal, exists := c.Get("role_id")
+	if exists {
+		if roleID, ok := roleIDVal.(uint32); ok && roleID == model.RoleTherapist {
+			therapistID, err := resolveTherapistIDFromSession(c, db)
+			if err != nil {
+				handleSessionError(c, err)
+				return
+			}
+			if existingTreatment.TherapistID != uint(therapistID) {
+				util.CallUserNotAuthorized(c, util.APIErrorParams{
+					Msg: "You can only edit treatments assigned to you",
+					Err: fmt.Errorf("therapist ID mismatch: treatment has therapist %d, but session has therapist %d", existingTreatment.TherapistID, therapistID),
+				})
+				return
+			}
+			if updates.TherapistID != 0 && updates.TherapistID != uint(therapistID) {
+				util.CallUserError(c, util.APIErrorParams{
+					Msg: "You cannot change the therapist assigned to this treatment",
+					Err: fmt.Errorf("therapist cannot reassign treatment to therapist %d", updates.TherapistID),
+				})
+				return
+			}
+		}
+	}
+
 	if err := db.Model(existingTreatment).Updates(updates).Error; err != nil {
 		util.CallServerError(c, util.APIErrorParams{
 			Msg: "Failed to update treatment",

--- a/endpoint/treatment_test.go
+++ b/endpoint/treatment_test.go
@@ -714,7 +714,7 @@ func TestUpdateTreatment_TherapistReassign_Forbidden(t *testing.T) {
 		headers:      map[string]string{"session-token": session.SessionToken},
 	})
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 	assert.NoError(t, err)
 }
 

--- a/endpoint/treatment_test.go
+++ b/endpoint/treatment_test.go
@@ -604,6 +604,120 @@ func TestGetDBOrAbort_NoDatabase(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestUpdateTreatment_TherapistOwner_Success(t *testing.T) {
+	r, db := setupTreatmentTest(t)
+
+	// Create user, therapist and session
+	_, therapist, session := createUserWithSession(db, t, CreateUserSessionOpts{
+		RoleID:          model.RoleTherapist,
+		Email:           "therapist@owner.com",
+		Token:           "owner-token",
+		CreateTherapist: true,
+	})
+
+	treatment := createTestTreatment(db, t, "UPD001", therapist.ID)
+
+	reqBody := map[string]interface{}{
+		"remarks": "Updated by therapist",
+	}
+
+	handler := func(c *gin.Context) {
+		c.Set("role_id", model.RoleTherapist)
+		c.Request.Header.Set("session-token", session.SessionToken)
+		UpdateTreatment(c)
+	}
+
+	w, _, err := doRequestWithHandler(r, requestSpec{
+		method:       http.MethodPatch,
+		registerPath: "/treatment/:id",
+		requestPath:  fmt.Sprintf("/treatment/%d", treatment.ID),
+		handler:      handler,
+		body:         reqBody,
+		headers:      map[string]string{"session-token": session.SessionToken},
+	})
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, err)
+
+	// Verify update
+	var updated model.Treatment
+	db.First(&updated, treatment.ID)
+	assert.Equal(t, "Updated by therapist", updated.Remarks)
+}
+
+func TestUpdateTreatment_TherapistNonOwner_Unauthorized(t *testing.T) {
+	r, db := setupTreatmentTest(t)
+
+	// Create therapist user and session
+	_, _, session := createUserWithSession(db, t, CreateUserSessionOpts{
+		RoleID:          model.RoleTherapist,
+		Email:           "therapist@owner.com",
+		Token:           "owner-token",
+		CreateTherapist: true,
+	})
+
+	// Create treatment belonging to another therapist (ID 999)
+	treatment := createTestTreatment(db, t, "UPD002", 999)
+
+	reqBody := map[string]interface{}{
+		"remarks": "Updated by unauthorized therapist",
+	}
+
+	handler := func(c *gin.Context) {
+		c.Set("role_id", model.RoleTherapist)
+		c.Request.Header.Set("session-token", session.SessionToken)
+		UpdateTreatment(c)
+	}
+
+	w, _, err := doRequestWithHandler(r, requestSpec{
+		method:       http.MethodPatch,
+		registerPath: "/treatment/:id",
+		requestPath:  fmt.Sprintf("/treatment/%d", treatment.ID),
+		handler:      handler,
+		body:         reqBody,
+		headers:      map[string]string{"session-token": session.SessionToken},
+	})
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.NoError(t, err)
+}
+
+func TestUpdateTreatment_TherapistReassign_Forbidden(t *testing.T) {
+	r, db := setupTreatmentTest(t)
+
+	// Create therapist user and session
+	_, therapist, session := createUserWithSession(db, t, CreateUserSessionOpts{
+		RoleID:          model.RoleTherapist,
+		Email:           "therapist@owner.com",
+		Token:           "owner-token",
+		CreateTherapist: true,
+	})
+
+	treatment := createTestTreatment(db, t, "UPD003", therapist.ID)
+
+	reqBody := map[string]interface{}{
+		"therapist_id": 999, // Attempt to reassign therapist
+	}
+
+	handler := func(c *gin.Context) {
+		c.Set("role_id", model.RoleTherapist)
+		c.Request.Header.Set("session-token", session.SessionToken)
+		UpdateTreatment(c)
+	}
+
+	w, _, err := doRequestWithHandler(r, requestSpec{
+		method:       http.MethodPatch,
+		registerPath: "/treatment/:id",
+		requestPath:  fmt.Sprintf("/treatment/%d", treatment.ID),
+		handler:      handler,
+		body:         reqBody,
+		headers:      map[string]string{"session-token": session.SessionToken},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NoError(t, err)
+}
+
 // Test helper functions
 func parseQueryIntTest(c *gin.Context, key string, defaultValue int) int {
 	value := c.Query(key)

--- a/endpoint/users.go
+++ b/endpoint/users.go
@@ -429,7 +429,15 @@ func GetUserInfo(c *gin.Context) {
 
 	var therapistID uint
 	if user.RoleID == model.RoleTherapist {
-		db.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+		tx := db.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+		if tx.Error != nil {
+			util.CallServerError(c, util.APIErrorParams{Msg: "Failed to load therapist info", Err: tx.Error})
+			return
+		}
+		if tx.RowsAffected == 0 {
+			util.CallServerError(c, util.APIErrorParams{Msg: "Therapist record not found for user", Err: fmt.Errorf("therapist not found for email %s", user.Email)})
+			return
+		}
 	}
 
 	data := map[string]interface{}{

--- a/endpoint/users.go
+++ b/endpoint/users.go
@@ -427,7 +427,22 @@ func GetUserInfo(c *gin.Context) {
 		return
 	}
 
-	util.CallSuccessOK(c, util.APISuccessParams{Msg: "User retrieved", Data: user})
+	var therapistID uint
+	if user.RoleID == model.RoleTherapist {
+		db.Table("therapists").Select("id").Where("email = ? AND deleted_at IS NULL", user.Email).Scan(&therapistID)
+	}
+
+	data := map[string]interface{}{
+		"id":           user.ID,
+		"name":         user.Name,
+		"email":        user.Email,
+		"role_id":      user.RoleID,
+		"therapist_id": therapistID,
+		"created_at":   user.CreatedAt,
+		"updated_at":   user.UpdatedAt,
+	}
+
+	util.CallSuccessOK(c, util.APISuccessParams{Msg: "User retrieved", Data: data})
 }
 
 // UpdateUserByID is a compatibility wrapper that calls AdminUpdateUser

--- a/main.go
+++ b/main.go
@@ -233,9 +233,9 @@ func registerPatientRoutes(auth *gin.RouterGroup) {
 func registerTreatmentRoutes(auth *gin.RouterGroup) {
 	treatment := auth.Group("/treatment")
 	treatment.GET("", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist, model.RoleUser), endpoint.ListTreatments)
-	treatment.POST("", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.CreateTreatment)
+	treatment.POST("", middleware.RequireRole(model.RoleAdmin), endpoint.CreateTreatment)
 	treatment.PATCH("/:id", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.UpdateTreatment)
-	treatment.DELETE("/:id", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.DeleteTreatment)
+	treatment.DELETE("/:id", middleware.RequireRole(model.RoleAdmin), endpoint.DeleteTreatment)
 }
 
 func registerDiseaseRoutes(auth *gin.RouterGroup) {

--- a/main.go
+++ b/main.go
@@ -232,11 +232,10 @@ func registerPatientRoutes(auth *gin.RouterGroup) {
 
 func registerTreatmentRoutes(auth *gin.RouterGroup) {
 	treatment := auth.Group("/treatment")
-	treatment.Use(middleware.RequireRole(model.RoleAdmin, model.RoleTherapist))
-	treatment.GET("", endpoint.ListTreatments)
-	treatment.POST("", endpoint.CreateTreatment)
-	treatment.PATCH("/:id", endpoint.UpdateTreatment)
-	treatment.DELETE("/:id", endpoint.DeleteTreatment)
+	treatment.GET("", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist, model.RoleUser), endpoint.ListTreatments)
+	treatment.POST("", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.CreateTreatment)
+	treatment.PATCH("/:id", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.UpdateTreatment)
+	treatment.DELETE("/:id", middleware.RequireRole(model.RoleAdmin, model.RoleTherapist), endpoint.DeleteTreatment)
 }
 
 func registerDiseaseRoutes(auth *gin.RouterGroup) {

--- a/util/helperfunc.go
+++ b/util/helperfunc.go
@@ -110,7 +110,6 @@ func CallUserForbidden(c *gin.Context, params APIErrorParams) {
 	c.JSON(http.StatusForbidden, response)
 }
 
-
 // NormalizeName normalizes a name by trimming leading/trailing whitespace
 // and collapsing multiple internal spaces into single spaces.
 // This ensures consistent name formatting and helps prevent duplicate detection bypass.

--- a/util/helperfunc.go
+++ b/util/helperfunc.go
@@ -89,7 +89,7 @@ func CallUserFound(c *gin.Context, params APISuccessParams) {
 	c.JSON(http.StatusTemporaryRedirect, response)
 }
 
-// CallUserNotAuthorized is for return API response with status code 403, you need to specify msg, and data as function paramenter
+// CallUserNotAuthorized is for return API response with status code 401 Unauthorized
 func CallUserNotAuthorized(c *gin.Context, params APIErrorParams) {
 	response := APIResponse{
 		Success: false,
@@ -98,6 +98,18 @@ func CallUserNotAuthorized(c *gin.Context, params APIErrorParams) {
 	}
 	c.JSON(http.StatusUnauthorized, response)
 }
+
+// CallUserForbidden is for return API response with status code 403 Forbidden
+func CallUserForbidden(c *gin.Context, params APIErrorParams) {
+	response := APIResponse{
+		Success: false,
+		Error:   params.Err.Error(),
+		Msg:     params.Msg,
+		Data:    map[string]interface{}{},
+	}
+	c.JSON(http.StatusForbidden, response)
+}
+
 
 // NormalizeName normalizes a name by trimming leading/trailing whitespace
 // and collapsing multiple internal spaces into single spaces.


### PR DESCRIPTION
This pull request introduces enhanced role-based access controls for treatment endpoints, improves the handling and exposure of therapist identity in authentication and user info responses, and adds comprehensive tests for the new authorization logic. The main focus is on ensuring that therapists can only update treatments assigned to them and cannot reassign treatments, while also surfacing therapist IDs where relevant.

**Access control improvements for treatments:**
- Therapists can now only update treatments assigned to themselves and are forbidden from reassigning treatments to other therapists. Admins retain full access.
- Treatment endpoint routes have been updated to enforce stricter role requirements: only admins can create or delete treatments, while both admins and therapists can update, and users can list treatments.

**Therapist identity exposure:**
- The `LoginResponse` struct and login logic now include a `TherapistID` field for therapist users, making this information available immediately after login. [[1]](diffhunk://#diff-5a196eff250ba42cffc5c8ce24386f6a0500bec06b7ddbf48e30d1442de2e11dR27) [[2]](diffhunk://#diff-5a196eff250ba42cffc5c8ce24386f6a0500bec06b7ddbf48e30d1442de2e11dR227-R238)
- The user info endpoint now includes `therapist_id` in its response for therapist users, providing consistent access to this identifier.

**Testing:**
- New tests verify that therapists can only update their own treatments, are unauthorized when attempting to update others’ treatments, and are forbidden from reassigning treatments to other therapists.